### PR TITLE
IVE-171: fix zephyr builds

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -63,7 +63,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: voxelbotics-v3.4.99-ncs1-1
+      revision: voxelbotics-v3.4.99-ncs1-1-branch
       remote: voxelbotics
       import:
         # In addition to the zephyr repository itself, NCS also


### PR DESCRIPTION
IVE-171: switch zephyr remote to the HEAD of the current zephyr dev branch instead of a fixed tag