### PR TITLE
IVE-195: Update modem_antenna library

### DIFF
--- a/lib/modem_antenna/Kconfig
+++ b/lib/modem_antenna/Kconfig
@@ -41,6 +41,43 @@ config MODEM_ANTENNA_AT_COEX0
 	  Defines the AT%XCOEX0 command to be sent to the modem. Leave
 	  empty if this command should not be sent.
 
+config MODEM_ANTENNA_AT_COEX2
+	string "AT%XCOEX2 command"
+	default "AT\%XCOEX2"
+	help
+	  Defines the AT%XCOEX2 command to be sent to the modem. Leave
+	  empty if this command should not be sent.
+
+config MODEM_ANTENNA_AT_MIPIRFFEDEV
+	string "AT%XMIPIRFFEDEV command"
+	help
+	  Defines the AT%XMIPIRFFEDEV command to be sent to the modem. Leave
+	  empty if this command should not be sent.
+
+config MODEM_ANTENNA_AT_MIPIRFFECTRL_INIT
+	string "AT%XMIPIRFFECTRL command (INIT)"
+	help
+	  Defines the AT%XMIPIRFFECTRL command to be sent to the modem for INIT phase.
+	  Leave empty if this command should not be sent.
+
+config MODEM_ANTENNA_AT_MIPIRFFECTRL_ON
+	string "AT%XMIPIRFFECTRL command (ON)"
+	help
+	  Defines the AT%XMIPIRFFECTRL command to be sent to the modem for ON phase.
+	  Leave empty if this command should not be sent.
+
+config MODEM_ANTENNA_AT_MIPIRFFECTRL_OFF
+	string "AT%XMIPIRFFECTRL command (OFF)"
+	help
+	  Defines the AT%XMIPIRFFECTRL command to be sent to the modem for OFF phase.
+	  Leave empty if this command should not be sent.
+
+config MODEM_ANTENNA_AT_MIPIRFFECTRL_PWROFF
+	string "AT%XMIPIRFFECTRL command (PWROFF)"
+	help
+	  Defines the AT%XMIPIRFFECTRL command to be sent to the modem for PWROFF phase.
+	  Leave empty if this command should not be sent.
+
 module=MODEM_ANTENNA
 module-dep=LOG
 module-str=Modem antenna

--- a/lib/modem_antenna/modem_antenna.c
+++ b/lib/modem_antenna/modem_antenna.c
@@ -13,27 +13,31 @@ LOG_MODULE_REGISTER(modem_antenna, CONFIG_MODEM_ANTENNA_LOG_LEVEL);
 
 NRF_MODEM_LIB_ON_INIT(gnss_cfg_init_hook, on_modem_lib_init, NULL);
 
-static void on_modem_lib_init(int ret, void *ctx)
+void set_antenna_configuration(const char *config_value)
 {
 	int err;
 
+	if (strlen(config_value) > 0) {
+		LOG_DBG("Setting configuration: %s", config_value);
+		err = nrf_modem_at_printf("%s", config_value);
+		if (err) {
+			LOG_ERR("Failed to set configuration (err: %d)", err);
+		}
+	}
+}
+
+static void on_modem_lib_init(int ret, void *ctx)
+{
 	if (ret != 0) {
 		return;
 	}
 
-	if (strlen(CONFIG_MODEM_ANTENNA_AT_MAGPIO) > 0) {
-		LOG_DBG("Setting MAGPIO configuration: %s", CONFIG_MODEM_ANTENNA_AT_MAGPIO);
-		err = nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_MAGPIO);
-		if (err) {
-			LOG_ERR("Failed to set MAGPIO configuration (err: %d)", err);
-		}
-	}
-
-	if (strlen(CONFIG_MODEM_ANTENNA_AT_COEX0) > 0) {
-		LOG_DBG("Setting COEX0 configuration: %s", CONFIG_MODEM_ANTENNA_AT_COEX0);
-		err = nrf_modem_at_printf("%s", CONFIG_MODEM_ANTENNA_AT_COEX0);
-		if (err) {
-			LOG_ERR("Failed to set COEX0 configuration (err: %d)", err);
-		}
-	}
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MAGPIO);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_COEX0);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_COEX2);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MIPIRFFEDEV);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_INIT);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_ON);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_OFF);
+	set_antenna_configuration(CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_PWROFF);
 }


### PR DESCRIPTION
Add support for the following parameters:
CONFIG_MODEM_ANTENNA_AT_MIPIRFFEDEV
CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_INIT
CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_ON
CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_OFF
CONFIG_MODEM_ANTENNA_AT_MIPIRFFECTRL_PWROFF