### PR TITLE
IVE-204: Increase stack size for provisioning thread

### DIFF
--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning.c
@@ -585,7 +585,7 @@ int nrf_provisioning_req(void)
 	return ret;
 }
 
-#define NRF_PROVISIONING_STACK_SIZE 3072
+#define NRF_PROVISIONING_STACK_SIZE 4096
 #define NRF_PROVISIONING_PRIORITY 5
 
 K_THREAD_DEFINE(nrf_provisioning, NRF_PROVISIONING_STACK_SIZE,


### PR DESCRIPTION
Increase stack size from 3KB to 4KB