### PR TITLE
CB24FW-232: fix nrf cloud log processing

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_alert.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_alert.c
@@ -195,7 +195,7 @@ void nrf_cloud_alert_control_set(bool enable)
 	if (!IS_ENABLED(CONFIG_NRF_CLOUD_ALERT)) {
 		return;
 	}
-	LOG_DBG("Changing alerts_enabled from:%d to:%d", alerts_enabled, enable);
+	LOG_INF("Changing alerts enabled from:%d to:%d", alerts_enabled, enable);
 	if (alerts_enabled != enable) {
 		alerts_enabled = enable;
 	}

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log.c
@@ -293,7 +293,7 @@ int nrf_cloud_log_control_get(void)
 void nrf_cloud_log_level_set(int level)
 {
 	if (nrf_cloud_log_level != level) {
-		LOG_DBG("Changing log level from:%d to:%d", nrf_cloud_log_level, level);
+		LOG_INF("Changing cloud log level from:%d to:%d", nrf_cloud_log_level, level);
 		nrf_cloud_log_level = level;
 	} else {
 		LOG_DBG("No change in log level from %d", level);
@@ -307,7 +307,7 @@ void nrf_cloud_log_enable(bool enable)
 		logs_backend_enable(enable);
 #endif
 		enabled = enable;
-		LOG_DBG("enabled = %d", enabled);
+		LOG_INF("Changing cloud logging enabled to:%d", enabled);
 	}
 }
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_log_backend.c
@@ -443,7 +443,6 @@ static int logger_out(uint8_t *buf, size_t size, void *ctx)
 	}
 
 	if (k_sem_take(&ncl_active, K_NO_WAIT) < 0) {
-		printk("logger_out: BUSY\n");
 		return 0;
 	}
 
@@ -454,10 +453,7 @@ static int logger_out(uint8_t *buf, size_t size, void *ctx)
 			 */
 			buf[size] = '\0';
 		} else {
-			printk("buf %p..%p is not inside our log_buf %p..%p\n",
-				buf, &buf[size], log_buf,
-				&log_buf[CONFIG_NRF_CLOUD_LOG_BUF_SIZE]);
-			return orig_size;
+			goto end;
 		}
 
 		extra = 3;


### PR DESCRIPTION
- Release semaphore on error and prevent the log processing thread from being locked forever
- Remove extra debug messages that may lead to undesired effects in situations with log message overflow
